### PR TITLE
Add fmt include to use the fmt version from externals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ include_directories("${EXTERNAL_DIR}/libuv/include")
 include_directories("${EXTERNAL_DIR}/libuv/src")
 include_directories("${EXTERNAL_DIR}/concurrentqueue")
 include_directories("${EXTERNAL_DIR}/cppcoro/include")
+include_directories("${EXTERNAL_DIR}/fmt/include")
 include_directories("${TOP_DIR}/include")
 
 if(USE_SPDLOG)


### PR DESCRIPTION
It was missing, I gues you have it local on your machine.

It now compiles on Debian testing (bullseye), when I pull gcc 10 from unstable (gcc-10 (Debian 10.2.0-3) 10.2.0)

Best regards,
Bob