### PR TITLE
Move registration of dependencies to optional constructor instead of dependency manager template

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ These benchmarks are mainly used to identify bottlenecks, not to showcase the pe
 
 Setup: AMD 3900X, 3600MHz@CL17 RAM, ubuntu 20.04
 * Start best case scenario: 10,000 starts with dependency in ~690ms
-* Start/stop best case scenario: 1,000,000 start/stops with dependency in ~800ms
+* Start/stop best case scenario: 1,000,000 start/stops with dependency in ~840ms
 * Serialization: Rapidjson: 1,000,000 messages serialized & deserialized in ~350 ms
 
 # Support

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ With this rewrite comes an opportunity to remove some features that are not used
 These benchmarks are mainly used to identify bottlenecks, not to showcase the performance of the framework. Comparisons between Cppelix, Celix and Felix will be made at a later date.
 
 Setup: AMD 3900X, 3600MHz@CL17 RAM, ubuntu 20.04
+* Start best case scenario: 10,000 starts with dependency in ~690ms
 * Start/stop best case scenario: 1,000,000 start/stops with dependency in ~800ms
 * Serialization: Rapidjson: 1,000,000 messages serialized & deserialized in ~350 ms
 

--- a/benchmarks/etcd_benchmark/UsingEtcdService.h
+++ b/benchmarks/etcd_benchmark/UsingEtcdService.h
@@ -15,12 +15,16 @@ struct IUsingEtcdService : virtual public IService {
 
 class UsingEtcdService final : public IUsingEtcdService, public Service {
 public:
+    UsingEtcdService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+        reg.registerDependency<IEtcdService>(this, true);
+    }
     ~UsingEtcdService() final = default;
 
     bool start() final {
         LOG_INFO(_logger, "UsingEtcdService started");
         auto start = std::chrono::system_clock::now();
-        for(uint64_t i = 0; i < 100'000; i++) {
+        for(uint64_t i = 0; i < 10'000; i++) {
             if(!_etcd->put("test" + std::to_string(i), "2") || !_etcd->get("test" + std::to_string(i))) {
                 throw std::runtime_error("Couldn't put or get");
             }

--- a/benchmarks/etcd_benchmark/main.cpp
+++ b/benchmarks/etcd_benchmark/main.cpp
@@ -8,14 +8,12 @@
 
 #define FRAMEWORK_LOGGER_TYPE SpdlogFrameworkLogger
 #define LOGGER_TYPE SpdlogLogger
-#define LOGGER_SHARED_TYPE ,ISpdlogSharedService
 #else
 #include <optional_bundles/logging_bundle/CoutFrameworkLogger.h>
 #include <optional_bundles/logging_bundle/CoutLogger.h>
 
 #define FRAMEWORK_LOGGER_TYPE CoutFrameworkLogger
 #define LOGGER_TYPE CoutLogger
-#define LOGGER_SHARED_TYPE
 #endif
 #include <string>
 
@@ -32,26 +30,26 @@ int main() {
     channel.addManager(&dmTwo);
 
     std::thread t1([&dmOne] {
-        auto logMgr = dmOne.createServiceManager<IFrameworkLogger, FRAMEWORK_LOGGER_TYPE>();
+        auto logMgr = dmOne.createServiceManager<FRAMEWORK_LOGGER_TYPE, IFrameworkLogger>();
         logMgr->setLogLevel(LogLevel::INFO);
 #ifdef USE_SPDLOG
-        dmOne.createServiceManager<ISpdlogSharedService, SpdlogSharedService>();
+        dmOne.createServiceManager<SpdlogSharedService, ISpdlogSharedService>();
 #endif
-        dmOne.createServiceManager<ILoggerAdmin, LoggerAdmin<LOGGER_TYPE LOGGER_SHARED_TYPE>>(RequiredList<IFrameworkLogger>);
-        dmOne.createServiceManager<IEtcdService, EtcdService>(RequiredList<ILogger>, OptionalList<>, CppelixProperties{{"EtcdAddress", "localhost:2379"s}});
-        dmOne.createServiceManager<IUsingEtcdService, UsingEtcdService>(RequiredList<ILogger, IEtcdService>, OptionalList<>);
+        dmOne.createServiceManager<LoggerAdmin<LOGGER_TYPE>, ILoggerAdmin>();
+        dmOne.createServiceManager<EtcdService, IEtcdService>(CppelixProperties{{"EtcdAddress", "localhost:2379"s}});
+        dmOne.createServiceManager<UsingEtcdService, IUsingEtcdService>();
         dmOne.start();
     });
 
     std::thread t2([&dmTwo] {
-        auto logMgr = dmTwo.createServiceManager<IFrameworkLogger, FRAMEWORK_LOGGER_TYPE>();
+        auto logMgr = dmTwo.createServiceManager<FRAMEWORK_LOGGER_TYPE, IFrameworkLogger>();
         logMgr->setLogLevel(LogLevel::INFO);
 #ifdef USE_SPDLOG
-        dmTwo.createServiceManager<ISpdlogSharedService, SpdlogSharedService>();
+        dmTwo.createServiceManager<SpdlogSharedService, ISpdlogSharedService>();
 #endif
-        dmTwo.createServiceManager<ILoggerAdmin, LoggerAdmin<LOGGER_TYPE LOGGER_SHARED_TYPE>>(RequiredList<IFrameworkLogger>);
-        dmTwo.createServiceManager<IEtcdService, EtcdService>(RequiredList<ILogger>, OptionalList<>, CppelixProperties{{"EtcdAddress", "localhost:2379"s}});
-        dmTwo.createServiceManager<IUsingEtcdService, UsingEtcdService>(RequiredList<ILogger, IEtcdService>, OptionalList<>);
+        dmTwo.createServiceManager<LoggerAdmin<LOGGER_TYPE>, ILoggerAdmin>();
+        dmTwo.createServiceManager<EtcdService, IEtcdService>(CppelixProperties{{"EtcdAddress", "localhost:2379"s}});
+        dmTwo.createServiceManager<UsingEtcdService, IUsingEtcdService>();
         dmTwo.start();
     });
 

--- a/benchmarks/serializer_benchmark/TestMsgJsonSerializer.h
+++ b/benchmarks/serializer_benchmark/TestMsgJsonSerializer.h
@@ -14,6 +14,10 @@ using namespace Cppelix;
 
 class TestMsgJsonSerializer final : public ISerializer, public Service {
 public:
+    TestMsgJsonSerializer(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+        reg.registerDependency<ISerializationAdmin>(this, true);
+    }
     ~TestMsgJsonSerializer() final = default;
     bool start() final {
         _serializationAdmin->addSerializer(typeNameHash<TestMsg>(), this);

--- a/benchmarks/serializer_benchmark/TestService.h
+++ b/benchmarks/serializer_benchmark/TestService.h
@@ -17,6 +17,10 @@ struct ITestService : virtual public IService {
 
 class TestService final : public ITestService, public Service {
 public:
+    TestService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+        reg.registerDependency<ISerializationAdmin>(this, true);
+    }
     ~TestService() final = default;
     bool start() final {
         LOG_INFO(_logger, "TestService started with dependency");

--- a/benchmarks/serializer_benchmark/main.cpp
+++ b/benchmarks/serializer_benchmark/main.cpp
@@ -7,29 +7,27 @@
 
 #define FRAMEWORK_LOGGER_TYPE SpdlogFrameworkLogger
 #define LOGGER_TYPE SpdlogLogger
-#define LOGGER_SHARED_TYPE ,ISpdlogSharedService
 #else
 #include <optional_bundles/logging_bundle/CoutFrameworkLogger.h>
 #include <optional_bundles/logging_bundle/CoutLogger.h>
 
 #define FRAMEWORK_LOGGER_TYPE CoutFrameworkLogger
 #define LOGGER_TYPE CoutLogger
-#define LOGGER_SHARED_TYPE
 #endif
 
 int main() {
     std::locale::global(std::locale("en_US.UTF-8"));
 
     DependencyManager dm{};
-    auto logMgr = dm.createServiceManager<IFrameworkLogger, FRAMEWORK_LOGGER_TYPE>();
+    auto logMgr = dm.createServiceManager<FRAMEWORK_LOGGER_TYPE, IFrameworkLogger>();
     logMgr->setLogLevel(LogLevel::INFO);
 #ifdef USE_SPDLOG
-    dm.createServiceManager<ISpdlogSharedService, SpdlogSharedService>();
+    dm.createServiceManager<SpdlogSharedService, ISpdlogSharedService>();
 #endif
-    dm.createServiceManager<ILoggerAdmin, LoggerAdmin<LOGGER_TYPE LOGGER_SHARED_TYPE>>(RequiredList<IFrameworkLogger>);
-    dm.createServiceManager<ISerializationAdmin, SerializationAdmin>(RequiredList<ILogger>, OptionalList<>);
-    dm.createServiceManager<ISerializer, TestMsgJsonSerializer>(RequiredList<ILogger, ISerializationAdmin>, OptionalList<>);
-    dm.createServiceManager<ITestService, TestService>(RequiredList<ILogger, ISerializationAdmin>, OptionalList<>);
+    dm.createServiceManager<LoggerAdmin<LOGGER_TYPE>, ILoggerAdmin>();
+    dm.createServiceManager<SerializationAdmin, ISerializationAdmin>();
+    dm.createServiceManager<TestMsgJsonSerializer, ISerializer>();
+    dm.createServiceManager<TestService, ITestService>();
     dm.start();
 
     return 0;

--- a/benchmarks/start_benchmark/TestService.h
+++ b/benchmarks/start_benchmark/TestService.h
@@ -14,6 +14,9 @@ struct ITestService : virtual public IService {
 
 class TestService final : public ITestService, public Service {
 public:
+    TestService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+    }
     ~TestService() final = default;
     bool start() final {
         if(std::any_cast<uint64_t>(getProperties()->operator[]("Iteration")) == 9'999) {

--- a/benchmarks/start_benchmark/main.cpp
+++ b/benchmarks/start_benchmark/main.cpp
@@ -7,14 +7,12 @@
 
 #define FRAMEWORK_LOGGER_TYPE SpdlogFrameworkLogger
 #define LOGGER_TYPE SpdlogLogger
-#define LOGGER_SHARED_TYPE ,ISpdlogSharedService
 #else
 #include <optional_bundles/logging_bundle/CoutFrameworkLogger.h>
 #include <optional_bundles/logging_bundle/CoutLogger.h>
 
 #define FRAMEWORK_LOGGER_TYPE CoutFrameworkLogger
 #define LOGGER_TYPE CoutLogger
-#define LOGGER_SHARED_TYPE
 #endif
 #include <iostream>
 
@@ -23,17 +21,17 @@ int main() {
 
     auto start = std::chrono::system_clock::now();
     DependencyManager dm{};
-    auto logMgr = dm.createServiceManager<IFrameworkLogger, FRAMEWORK_LOGGER_TYPE>();
+    auto logMgr = dm.createServiceManager<FRAMEWORK_LOGGER_TYPE, IFrameworkLogger>();
     logMgr->setLogLevel(LogLevel::INFO);
 
 
 #ifdef USE_SPDLOG
-    dm.createServiceManager<ISpdlogSharedService, SpdlogSharedService>();
+    dm.createServiceManager<SpdlogSharedService, ISpdlogSharedService>();
 #endif
 
-    dm.createServiceManager<ILoggerAdmin, LoggerAdmin<LOGGER_TYPE LOGGER_SHARED_TYPE>>(RequiredList<IFrameworkLogger>);
+    dm.createServiceManager<LoggerAdmin<LOGGER_TYPE>, ILoggerAdmin>();
     for(uint64_t i = 0; i < 10'000; i++) {
-        dm.createServiceManager<ITestService, TestService>(RequiredList<ILogger>, OptionalList<>, CppelixProperties{{"Iteration", i}, {"LogLevel", LogLevel::WARN}});
+        dm.createServiceManager<TestService, ITestService>(CppelixProperties{{"Iteration", i}, {"LogLevel", LogLevel::WARN}});
     }
     dm.start();
     auto end = std::chrono::system_clock::now();

--- a/benchmarks/start_stop_benchmark/StartStopService.h
+++ b/benchmarks/start_stop_benchmark/StartStopService.h
@@ -15,6 +15,10 @@ struct IStartStopService : public virtual IService {
 
 class StartStopService final : public IStartStopService, public Service {
 public:
+    StartStopService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+        reg.registerDependency<ITestService>(this, true);
+    }
     ~StartStopService() final = default;
     bool start() final {
         if(startCount == 0) {

--- a/benchmarks/start_stop_benchmark/TestService.h
+++ b/benchmarks/start_stop_benchmark/TestService.h
@@ -14,6 +14,9 @@ struct ITestService : virtual public IService {
 
 class TestService final : public ITestService, public Service {
 public:
+    TestService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+    }
     ~TestService() final = default;
     bool start() final {
         return true;

--- a/benchmarks/start_stop_benchmark/main.cpp
+++ b/benchmarks/start_stop_benchmark/main.cpp
@@ -7,14 +7,12 @@
 
 #define FRAMEWORK_LOGGER_TYPE SpdlogFrameworkLogger
 #define LOGGER_TYPE SpdlogLogger
-#define LOGGER_SHARED_TYPE ,ISpdlogSharedService
 #else
 #include <optional_bundles/logging_bundle/CoutFrameworkLogger.h>
 #include <optional_bundles/logging_bundle/CoutLogger.h>
 
 #define FRAMEWORK_LOGGER_TYPE CoutFrameworkLogger
 #define LOGGER_TYPE CoutLogger
-#define LOGGER_SHARED_TYPE
 #endif
 
 uint64_t StartStopService::startCount = 0;
@@ -23,14 +21,14 @@ int main() {
     std::locale::global(std::locale("en_US.UTF-8"));
 
     DependencyManager dm{};
-    auto logMgr = dm.createServiceManager<IFrameworkLogger, FRAMEWORK_LOGGER_TYPE>();
+    auto logMgr = dm.createServiceManager<FRAMEWORK_LOGGER_TYPE, IFrameworkLogger>();
     logMgr->setLogLevel(LogLevel::INFO);
 #ifdef USE_SPDLOG
-    dm.createServiceManager<ISpdlogSharedService, SpdlogSharedService>();
+    dm.createServiceManager<SpdlogSharedService, ISpdlogSharedService>();
 #endif
-    dm.createServiceManager<ILoggerAdmin, LoggerAdmin<LOGGER_TYPE LOGGER_SHARED_TYPE>>(RequiredList<IFrameworkLogger>);
-    dm.createServiceManager<ITestService, TestService>(RequiredList<ILogger>, OptionalList<>, CppelixProperties{{"LogLevel", LogLevel::INFO}});
-    dm.createServiceManager<IStartStopService, StartStopService>(RequiredList<ILogger, ITestService>, OptionalList<>, CppelixProperties{{"LogLevel", LogLevel::INFO}});
+    dm.createServiceManager<LoggerAdmin<LOGGER_TYPE>, ILoggerAdmin>();
+    dm.createServiceManager<TestService, ITestService>(CppelixProperties{{"LogLevel", LogLevel::INFO}});
+    dm.createServiceManager<StartStopService, IStartStopService>(CppelixProperties{{"LogLevel", LogLevel::INFO}});
     dm.start();
 
     return 0;

--- a/examples/etcd_example/UsingEtcdService.h
+++ b/examples/etcd_example/UsingEtcdService.h
@@ -15,6 +15,10 @@ struct IUsingEtcdService : virtual public IService {
 
 class UsingEtcdService final : public IUsingEtcdService, public Service {
 public:
+    UsingEtcdService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+        reg.registerDependency<IEtcdService>(this, true);
+    }
     ~UsingEtcdService() final = default;
 
     bool start() final {

--- a/examples/etcd_example/main.cpp
+++ b/examples/etcd_example/main.cpp
@@ -7,14 +7,12 @@
 
 #define FRAMEWORK_LOGGER_TYPE SpdlogFrameworkLogger
 #define LOGGER_TYPE SpdlogLogger
-#define LOGGER_SHARED_TYPE ,ISpdlogSharedService
 #else
 #include <optional_bundles/logging_bundle/CoutFrameworkLogger.h>
 #include <optional_bundles/logging_bundle/CoutLogger.h>
 
 #define FRAMEWORK_LOGGER_TYPE CoutFrameworkLogger
 #define LOGGER_TYPE CoutLogger
-#define LOGGER_SHARED_TYPE
 #endif
 #include <chrono>
 #include <iostream>
@@ -26,13 +24,13 @@ int main() {
 
     auto start = std::chrono::system_clock::now();
     DependencyManager dm{};
-    dm.createServiceManager<IFrameworkLogger, FRAMEWORK_LOGGER_TYPE>();
+    dm.createServiceManager<FRAMEWORK_LOGGER_TYPE, IFrameworkLogger>();
 #ifdef USE_SPDLOG
-    dm.createServiceManager<ISpdlogSharedService, SpdlogSharedService>();
+    dm.createServiceManager<SpdlogSharedService, ISpdlogSharedService>();
 #endif
-    dm.createServiceManager<ILoggerAdmin, LoggerAdmin<LOGGER_TYPE LOGGER_SHARED_TYPE>>(RequiredList<IFrameworkLogger>);
-    dm.createServiceManager<IEtcdService, EtcdService>(RequiredList<ILogger>, OptionalList<>, CppelixProperties{{"EtcdAddress", "localhost:2379"s}});
-    dm.createServiceManager<IUsingEtcdService, UsingEtcdService>(RequiredList<ILogger, IEtcdService>, OptionalList<>);
+    dm.createServiceManager<LoggerAdmin<LOGGER_TYPE>, ILoggerAdmin>();
+    dm.createServiceManager<EtcdService, IEtcdService>(CppelixProperties{{"EtcdAddress", "localhost:2379"s}});
+    dm.createServiceManager<UsingEtcdService, IUsingEtcdService>();
     dm.start();
     auto end = std::chrono::system_clock::now();
     std::cout << fmt::format("Program ran for {:L} µs\n", std::chrono::duration_cast<std::chrono::microseconds>(end-start).count());

--- a/examples/event_statistics_example/UsingStatisticsService.h
+++ b/examples/event_statistics_example/UsingStatisticsService.h
@@ -15,11 +15,14 @@ struct IUsingStatisticsService : virtual public IService {
 
 class UsingStatisticsService final : public IUsingStatisticsService, public Service {
 public:
+    UsingStatisticsService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+    }
     ~UsingStatisticsService() final = default;
 
     bool start() final {
         LOG_INFO(_logger, "UsingStatisticsService started");
-        auto _timerManager = getManager()->createServiceManager<ITimer, Timer>();
+        auto _timerManager = getManager()->createServiceManager<Timer, ITimer>();
         _timerManager->setChronoInterval(std::chrono::seconds (15));
         _timerEventRegistration = getManager()->registerEventHandler<TimerEvent>(getServiceId(), this, _timerManager->getServiceId());
         _timerManager->startTimer();
@@ -43,7 +46,6 @@ public:
     Generator<bool> handleEvent(TimerEvent const * const evt) {
         getManager()->pushEvent<QuitEvent>(getServiceId(), INTERNAL_EVENT_PRIORITY+1);
 
-        // we handled it, false means no other handlers are allowed to handle this event.
         co_return (bool)PreventOthersHandling;
     }
 

--- a/examples/event_statistics_example/main.cpp
+++ b/examples/event_statistics_example/main.cpp
@@ -7,14 +7,12 @@
 
 #define FRAMEWORK_LOGGER_TYPE SpdlogFrameworkLogger
 #define LOGGER_TYPE SpdlogLogger
-#define LOGGER_SHARED_TYPE ,ISpdlogSharedService
 #else
 #include <optional_bundles/logging_bundle/CoutFrameworkLogger.h>
 #include <optional_bundles/logging_bundle/CoutLogger.h>
 
 #define FRAMEWORK_LOGGER_TYPE CoutFrameworkLogger
 #define LOGGER_TYPE CoutLogger
-#define LOGGER_SHARED_TYPE
 #endif
 #include <chrono>
 #include <iostream>
@@ -27,13 +25,13 @@ int main() {
 
     auto start = std::chrono::system_clock::now();
     DependencyManager dm{};
-    dm.createServiceManager<IFrameworkLogger, FRAMEWORK_LOGGER_TYPE>();
+    dm.createServiceManager<FRAMEWORK_LOGGER_TYPE, IFrameworkLogger>();
 #ifdef USE_SPDLOG
-    dm.createServiceManager<ISpdlogSharedService, SpdlogSharedService>();
+    dm.createServiceManager<SpdlogSharedService, ISpdlogSharedService>();
 #endif
-    dm.createServiceManager<ILoggerAdmin, LoggerAdmin<LOGGER_TYPE LOGGER_SHARED_TYPE>>(RequiredList<IFrameworkLogger>);
-    dm.createServiceManager<IEventStatisticsService, EventStatisticsService>(RequiredList<ILogger>, OptionalList<>, CppelixProperties{{"ShowStatisticsOnStop", true}});
-    dm.createServiceManager<IUsingStatisticsService, UsingStatisticsService>(RequiredList<ILogger>, OptionalList<>);
+    dm.createServiceManager<LoggerAdmin<LOGGER_TYPE>, ILoggerAdmin>();
+    dm.createServiceManager<EventStatisticsService, IEventStatisticsService>(CppelixProperties{{"ShowStatisticsOnStop", true}});
+    dm.createServiceManager<UsingStatisticsService, IUsingStatisticsService>();
     dm.start();
     auto end = std::chrono::system_clock::now();
     std::cout << fmt::format("Program ran for {:L} µs\n", std::chrono::duration_cast<std::chrono::microseconds>(end-start).count());

--- a/examples/multithreaded_example/OneService.h
+++ b/examples/multithreaded_example/OneService.h
@@ -16,6 +16,9 @@ struct IOneService : virtual public IService {
 
 class OneService final : public IOneService, public Service {
 public:
+    OneService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+    }
     ~OneService() final = default;
     bool start() final {
         LOG_INFO(_logger, "OneService started with dependency");

--- a/examples/multithreaded_example/OtherService.h
+++ b/examples/multithreaded_example/OtherService.h
@@ -14,6 +14,9 @@ struct IOtherService : virtual public IService {
 
 class OtherService final : public IOtherService, public Service {
 public:
+    OtherService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+    }
     ~OtherService() final = default;
     bool start() final {
         LOG_INFO(_logger, "OtherService started with dependency");

--- a/examples/multithreaded_example/main.cpp
+++ b/examples/multithreaded_example/main.cpp
@@ -7,14 +7,12 @@
 
 #define FRAMEWORK_LOGGER_TYPE SpdlogFrameworkLogger
 #define LOGGER_TYPE SpdlogLogger
-#define LOGGER_SHARED_TYPE ,ISpdlogSharedService
 #else
 #include <optional_bundles/logging_bundle/CoutFrameworkLogger.h>
 #include <optional_bundles/logging_bundle/CoutLogger.h>
 
 #define FRAMEWORK_LOGGER_TYPE CoutFrameworkLogger
 #define LOGGER_TYPE CoutLogger
-#define LOGGER_SHARED_TYPE
 #endif
 #include <framework/CommunicationChannel.h>
 #include <chrono>
@@ -33,22 +31,22 @@ int main() {
     channel.addManager(&dmTwo);
 
     std::thread t1([&dmOne] {
-        dmOne.createServiceManager<IFrameworkLogger, FRAMEWORK_LOGGER_TYPE>();
+        dmOne.createServiceManager<FRAMEWORK_LOGGER_TYPE, IFrameworkLogger>();
 #ifdef USE_SPDLOG
-        dmOne.createServiceManager<ISpdlogSharedService, SpdlogSharedService>();
+        dmOne.createServiceManager<SpdlogSharedService, ISpdlogSharedService>();
 #endif
-        dmOne.createServiceManager<ILoggerAdmin, LoggerAdmin<LOGGER_TYPE LOGGER_SHARED_TYPE>>(RequiredList<IFrameworkLogger>);
-        dmOne.createServiceManager<IOneService, OneService>(RequiredList<ILogger>, OptionalList<>);
+        dmOne.createServiceManager<LoggerAdmin<LOGGER_TYPE>, ILoggerAdmin>();
+        dmOne.createServiceManager<OneService, IOneService>();
         dmOne.start();
     });
 
     std::thread t2([&dmTwo] {
-        dmTwo.createServiceManager<IFrameworkLogger, FRAMEWORK_LOGGER_TYPE>();
+        dmTwo.createServiceManager<FRAMEWORK_LOGGER_TYPE, IFrameworkLogger>();
 #ifdef USE_SPDLOG
-        dmTwo.createServiceManager<ISpdlogSharedService, SpdlogSharedService>();
+        dmTwo.createServiceManager<SpdlogSharedService, ISpdlogSharedService>();
 #endif
-        dmTwo.createServiceManager<ILoggerAdmin, LoggerAdmin<LOGGER_TYPE LOGGER_SHARED_TYPE>>(RequiredList<IFrameworkLogger>);
-        dmTwo.createServiceManager<IOtherService, OtherService>(RequiredList<ILogger>, OptionalList<>);
+        dmTwo.createServiceManager<LoggerAdmin<LOGGER_TYPE>, ILoggerAdmin>();
+        dmTwo.createServiceManager<OtherService, IOtherService>();
         dmTwo.start();
     });
 

--- a/examples/serializer_example/TestMsgJsonSerializer.h
+++ b/examples/serializer_example/TestMsgJsonSerializer.h
@@ -12,9 +12,14 @@
 
 using namespace Cppelix;
 
-class TestMsgJsonSerializer : public ISerializer, public Service {
+class TestMsgJsonSerializer final : public ISerializer, public Service {
 public:
+    TestMsgJsonSerializer(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+        reg.registerDependency<ISerializationAdmin>(this, true);
+    }
     ~TestMsgJsonSerializer() final = default;
+
     bool start() final {
         LOG_INFO(_logger, "TestMsgSerializer started");
         _serializationAdmin->addSerializer(typeNameHash<TestMsg>(), this);

--- a/examples/serializer_example/TestService.h
+++ b/examples/serializer_example/TestService.h
@@ -16,7 +16,12 @@ struct ITestService : virtual public IService {
 
 class TestService final : public ITestService, public Service {
 public:
+    TestService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+        reg.registerDependency<ISerializationAdmin>(this, true);
+    }
     ~TestService() final = default;
+
     bool start() final {
         LOG_INFO(_logger, "TestService started with dependency");
         _doWorkRegistration = getManager()->registerEventCompletionCallbacks<DoWorkEvent>(getServiceId(), this);

--- a/examples/serializer_example/main.cpp
+++ b/examples/serializer_example/main.cpp
@@ -7,14 +7,12 @@
 
 #define FRAMEWORK_LOGGER_TYPE SpdlogFrameworkLogger
 #define LOGGER_TYPE SpdlogLogger
-#define LOGGER_SHARED_TYPE ,ISpdlogSharedService
 #else
 #include <optional_bundles/logging_bundle/CoutFrameworkLogger.h>
 #include <optional_bundles/logging_bundle/CoutLogger.h>
 
 #define FRAMEWORK_LOGGER_TYPE CoutFrameworkLogger
 #define LOGGER_TYPE CoutLogger
-#define LOGGER_SHARED_TYPE
 #endif
 #include <chrono>
 #include <iostream>
@@ -24,14 +22,14 @@ int main() {
 
     auto start = std::chrono::system_clock::now();
     DependencyManager dm{};
-    dm.createServiceManager<IFrameworkLogger, FRAMEWORK_LOGGER_TYPE>();
+    dm.createServiceManager<FRAMEWORK_LOGGER_TYPE, IFrameworkLogger>();
 #ifdef USE_SPDLOG
-    dm.createServiceManager<ISpdlogSharedService, SpdlogSharedService>();
+    dm.createServiceManager<SpdlogSharedService, ISpdlogSharedService>();
 #endif
-    dm.createServiceManager<ILoggerAdmin, LoggerAdmin<LOGGER_TYPE LOGGER_SHARED_TYPE>>(RequiredList<IFrameworkLogger>);
-    dm.createServiceManager<ISerializationAdmin, SerializationAdmin>(RequiredList<ILogger>, OptionalList<>);
-    dm.createServiceManager<ISerializer, TestMsgJsonSerializer>(RequiredList<ILogger, ISerializationAdmin>, OptionalList<>);
-    dm.createServiceManager<ITestService, TestService>(RequiredList<ILogger, ISerializationAdmin>, OptionalList<>);
+    dm.createServiceManager<LoggerAdmin<LOGGER_TYPE>, ILoggerAdmin>();
+    dm.createServiceManager<SerializationAdmin, ISerializationAdmin>();
+    dm.createServiceManager<TestMsgJsonSerializer, ISerializer>();
+    dm.createServiceManager<TestService, ITestService>();
     dm.start();
     auto end = std::chrono::system_clock::now();
     std::cout << fmt::format("Program ran for {:L} µs\n", std::chrono::duration_cast<std::chrono::microseconds>(end-start).count());

--- a/examples/tcp_example/TestMsgJsonSerializer.h
+++ b/examples/tcp_example/TestMsgJsonSerializer.h
@@ -14,7 +14,12 @@ using namespace Cppelix;
 
 class TestMsgJsonSerializer final : public ISerializer, public Service {
 public:
+    TestMsgJsonSerializer(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+        reg.registerDependency<ISerializationAdmin>(this, true);
+    }
     ~TestMsgJsonSerializer() final = default;
+
     bool start() final {
         LOG_INFO(_logger, "TestMsgSerializer started");
         _serializationAdmin->addSerializer(typeNameHash<TestMsg>(), this);

--- a/examples/tcp_example/UsingTcpService.h
+++ b/examples/tcp_example/UsingTcpService.h
@@ -20,6 +20,11 @@ struct IUsingTcpService : virtual public IService {
 
 class UsingTcpService final : public IUsingTcpService, public Service {
 public:
+    UsingTcpService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+        reg.registerDependency<ISerializationAdmin>(this, true);
+        reg.registerDependency<IConnectionService>(this, true);
+    }
     ~UsingTcpService() final = default;
 
     bool start() final {
@@ -73,7 +78,6 @@ public:
         LOG_INFO(_logger, "Received TestMsg id {} val {}", msg->id, msg->val);
         getManager()->pushEvent<QuitEvent>(getServiceId());
 
-        // we handled it, false means no other handlers are allowed to handle this event.
         co_return (bool)PreventOthersHandling;
     }
 

--- a/examples/tcp_example/UsingTcpService.h
+++ b/examples/tcp_example/UsingTcpService.h
@@ -23,7 +23,7 @@ public:
     UsingTcpService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
         reg.registerDependency<ILogger>(this, true);
         reg.registerDependency<ISerializationAdmin>(this, true);
-        reg.registerDependency<IConnectionService>(this, true);
+        reg.registerDependency<IConnectionService>(this, true, *getProperties());
     }
     ~UsingTcpService() final = default;
 

--- a/examples/tcp_example/main.cpp
+++ b/examples/tcp_example/main.cpp
@@ -9,14 +9,12 @@
 
 #define FRAMEWORK_LOGGER_TYPE SpdlogFrameworkLogger
 #define LOGGER_TYPE SpdlogLogger
-#define LOGGER_SHARED_TYPE ,ISpdlogSharedService
 #else
 #include <optional_bundles/logging_bundle/CoutFrameworkLogger.h>
 #include <optional_bundles/logging_bundle/CoutLogger.h>
 
 #define FRAMEWORK_LOGGER_TYPE CoutFrameworkLogger
 #define LOGGER_TYPE CoutLogger
-#define LOGGER_SHARED_TYPE
 #endif
 #include <chrono>
 #include <iostream>
@@ -28,16 +26,16 @@ int main() {
 
     auto start = std::chrono::system_clock::now();
     DependencyManager dm{};
-    dm.createServiceManager<IFrameworkLogger, FRAMEWORK_LOGGER_TYPE>();
+    dm.createServiceManager<FRAMEWORK_LOGGER_TYPE, IFrameworkLogger>();
 #ifdef USE_SPDLOG
-    dm.createServiceManager<ISpdlogSharedService, SpdlogSharedService>();
+    dm.createServiceManager<SpdlogSharedService, ISpdlogSharedService>();
 #endif
-    dm.createServiceManager<ILoggerAdmin, LoggerAdmin<LOGGER_TYPE LOGGER_SHARED_TYPE>>(RequiredList<IFrameworkLogger>);
-    dm.createServiceManager<ISerializationAdmin, SerializationAdmin>(RequiredList<ILogger>, OptionalList<>);
-    dm.createServiceManager<ISerializer, TestMsgJsonSerializer>(RequiredList<ILogger, ISerializationAdmin>, OptionalList<>);
-    dm.createServiceManager<IHostService, TcpHostService>(RequiredList<ILogger>, OptionalList<>, CppelixProperties{{"Address", "127.0.0.1"s}, {"Port", (uint16_t)8001}});
-    dm.createServiceManager<IClientAdmin, ClientAdmin<TcpConnectionService>>();
-    dm.createServiceManager<IUsingTcpService, UsingTcpService>(RequiredList<ILogger, ISerializationAdmin, IConnectionService>, OptionalList<>, CppelixProperties{{"Address", "127.0.0.1"s}, {"Port", (uint16_t)8001}});
+    dm.createServiceManager<LoggerAdmin<LOGGER_TYPE>, ILoggerAdmin>();
+    dm.createServiceManager<SerializationAdmin, ISerializationAdmin>();
+    dm.createServiceManager<TestMsgJsonSerializer, ISerializer>();
+    dm.createServiceManager<TcpHostService, IHostService>(CppelixProperties{{"Address", "127.0.0.1"s}, {"Port", (uint16_t)8001}});
+    dm.createServiceManager<ClientAdmin<TcpConnectionService>, IClientAdmin>();
+    dm.createServiceManager<UsingTcpService, IUsingTcpService>(CppelixProperties{{"Address", "127.0.0.1"s}, {"Port", (uint16_t)8001}});
     dm.start();
     auto end = std::chrono::system_clock::now();
     std::cout << fmt::format("Program ran for {:L} µs\n", std::chrono::duration_cast<std::chrono::microseconds>(end-start).count());

--- a/examples/timer_example/UsingTimerService.h
+++ b/examples/timer_example/UsingTimerService.h
@@ -15,11 +15,14 @@ struct IUsingTimerService : virtual public IService {
 
 class UsingTimerService final : public IUsingTimerService, public Service {
 public:
+    UsingTimerService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+    }
     ~UsingTimerService() final = default;
 
     bool start() final {
         LOG_INFO(_logger, "UsingTimerService started");
-        _timerManager = getManager()->createServiceManager<ITimer, Timer>();
+        _timerManager = getManager()->createServiceManager<Timer, ITimer>();
         _timerManager->setChronoInterval(std::chrono::milliseconds(500));
         _timerEventRegistration = getManager()->registerEventHandler<TimerEvent>(getServiceId(), this, _timerManager->getServiceId());
         _timerManager->startTimer();
@@ -48,7 +51,6 @@ public:
             getManager()->pushEvent<QuitEvent>(getServiceId(), INTERNAL_EVENT_PRIORITY+1);
         }
 
-        // we handled it, false means no other handlers are allowed to handle this event.
         co_return (bool)PreventOthersHandling;
     }
 

--- a/examples/timer_example/main.cpp
+++ b/examples/timer_example/main.cpp
@@ -6,14 +6,12 @@
 
 #define FRAMEWORK_LOGGER_TYPE SpdlogFrameworkLogger
 #define LOGGER_TYPE SpdlogLogger
-#define LOGGER_SHARED_TYPE ,ISpdlogSharedService
 #else
 #include <optional_bundles/logging_bundle/CoutFrameworkLogger.h>
 #include <optional_bundles/logging_bundle/CoutLogger.h>
 
 #define FRAMEWORK_LOGGER_TYPE CoutFrameworkLogger
 #define LOGGER_TYPE CoutLogger
-#define LOGGER_SHARED_TYPE
 #endif
 #include <chrono>
 #include <iostream>
@@ -25,13 +23,13 @@ int main() {
 
     auto start = std::chrono::system_clock::now();
     DependencyManager dm{};
-    auto logMgr = dm.createServiceManager<IFrameworkLogger, FRAMEWORK_LOGGER_TYPE>();
+    auto logMgr = dm.createServiceManager<FRAMEWORK_LOGGER_TYPE, IFrameworkLogger>();
 #ifdef USE_SPDLOG
-    dm.createServiceManager<ISpdlogSharedService, SpdlogSharedService>();
+    dm.createServiceManager<SpdlogSharedService, ISpdlogSharedService>();
 #endif
-    dm.createServiceManager<ILoggerAdmin, LoggerAdmin<LOGGER_TYPE LOGGER_SHARED_TYPE>>(RequiredList<IFrameworkLogger>);
-    dm.createServiceManager<IUsingTimerService, UsingTimerService>(RequiredList<ILogger>, OptionalList<>);
-    dm.createServiceManager<IUsingTimerService, UsingTimerService>(RequiredList<ILogger>, OptionalList<>);
+    dm.createServiceManager<LoggerAdmin<LOGGER_TYPE>, ILoggerAdmin>();
+    dm.createServiceManager<UsingTimerService, IUsingTimerService>();
+    dm.createServiceManager<UsingTimerService, IUsingTimerService>();
     dm.start();
     auto end = std::chrono::system_clock::now();
     std::cout << fmt::format("Program ran for {:L} µs\n", std::chrono::duration_cast<std::chrono::microseconds>(end-start).count());

--- a/examples/tracker_example/TestService.h
+++ b/examples/tracker_example/TestService.h
@@ -17,7 +17,7 @@ class TestService final : public ITestService, public Service {
 public:
     TestService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
         reg.registerDependency<ILogger>(this, true);
-        reg.registerDependency<IRuntimeCreatedService>(this, true);
+        reg.registerDependency<IRuntimeCreatedService>(this, true, *getProperties());
     }
     ~TestService() final = default;
     bool start() final {

--- a/examples/tracker_example/TestService.h
+++ b/examples/tracker_example/TestService.h
@@ -15,6 +15,10 @@ struct ITestService : virtual public IService {
 
 class TestService final : public ITestService, public Service {
 public:
+    TestService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+        reg.registerDependency<IRuntimeCreatedService>(this, true);
+    }
     ~TestService() final = default;
     bool start() final {
         LOG_INFO(_logger, "TestService started with dependency");

--- a/examples/tracker_example/TrackerService.h
+++ b/examples/tracker_example/TrackerService.h
@@ -30,6 +30,9 @@ struct ITrackerService : virtual public IService {
 
 class TrackerService final : public ITrackerService, public Service {
 public:
+    TrackerService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+    }
     ~TrackerService() final = default;
     bool start() final {
         LOG_INFO(_logger, "TrackerService started");
@@ -70,7 +73,7 @@ public:
             auto newProps = *evt->properties;
             newProps.emplace("Filter", Filter{ScopeFilterEntry{scope}});
 
-            _scopedRuntimeServices.emplace(scope, getManager()->createServiceManager<IRuntimeCreatedService, RuntimeCreatedService>(RequiredList<ILogger>, OptionalList<>, newProps));
+            _scopedRuntimeServices.emplace(scope, getManager()->createServiceManager<RuntimeCreatedService, IRuntimeCreatedService>(newProps));
         }
     }
 

--- a/examples/tracker_example/TrackerService.h
+++ b/examples/tracker_example/TrackerService.h
@@ -56,9 +56,14 @@ public:
     }
 
     void handleDependencyRequest(IRuntimeCreatedService*, DependencyRequestEvent const * const evt) {
-        auto scopeProp = evt->properties->find("scope");
+        if(!evt->properties.has_value()) {
+            LOG_ERROR(_logger, "missing properties");
+            return;
+        }
 
-        if(scopeProp == end(*evt->properties)) {
+        auto scopeProp = evt->properties.value()->find("scope");
+
+        if(scopeProp == end(*evt->properties.value())) {
             LOG_ERROR(_logger, "scope missing");
             return;
         }
@@ -70,7 +75,7 @@ public:
         auto runtimeService = _scopedRuntimeServices.find(scope);
 
         if(runtimeService == end(_scopedRuntimeServices)) {
-            auto newProps = *evt->properties;
+            auto newProps = *evt->properties.value();
             newProps.emplace("Filter", Filter{ScopeFilterEntry{scope}});
 
             _scopedRuntimeServices.emplace(scope, getManager()->createServiceManager<RuntimeCreatedService, IRuntimeCreatedService>(newProps));

--- a/examples/tracker_example/main.cpp
+++ b/examples/tracker_example/main.cpp
@@ -8,14 +8,12 @@
 
 #define FRAMEWORK_LOGGER_TYPE SpdlogFrameworkLogger
 #define LOGGER_TYPE SpdlogLogger
-#define LOGGER_SHARED_TYPE ,ISpdlogSharedService
 #else
 #include <optional_bundles/logging_bundle/CoutFrameworkLogger.h>
 #include <optional_bundles/logging_bundle/CoutLogger.h>
 
 #define FRAMEWORK_LOGGER_TYPE CoutFrameworkLogger
 #define LOGGER_TYPE CoutLogger
-#define LOGGER_SHARED_TYPE
 #endif
 #include <chrono>
 #include <iostream>
@@ -27,14 +25,14 @@ int main() {
 
     auto start = std::chrono::system_clock::now();
     DependencyManager dm{};
-    dm.createServiceManager<IFrameworkLogger, FRAMEWORK_LOGGER_TYPE>();
+    dm.createServiceManager<FRAMEWORK_LOGGER_TYPE, IFrameworkLogger>();
 #ifdef USE_SPDLOG
-    dm.createServiceManager<ISpdlogSharedService, SpdlogSharedService>();
+    dm.createServiceManager<SpdlogSharedService, ISpdlogSharedService>();
 #endif
-    dm.createServiceManager<ILoggerAdmin, LoggerAdmin<LOGGER_TYPE LOGGER_SHARED_TYPE>>(RequiredList<IFrameworkLogger>);
-    dm.createServiceManager<ITestService, TestService>(RequiredList<ILogger, IRuntimeCreatedService>, OptionalList<>, CppelixProperties{{"scope", "one"s}});
-    dm.createServiceManager<ITestService, TestService>(RequiredList<ILogger, IRuntimeCreatedService>, OptionalList<>, CppelixProperties{{"scope", "two"s}});
-    dm.createServiceManager<ITrackerService, TrackerService>(RequiredList<ILogger>, OptionalList<>);
+    dm.createServiceManager<LoggerAdmin<LOGGER_TYPE>, ILoggerAdmin>();
+    dm.createServiceManager<TestService, ITestService>(CppelixProperties{{"scope", "one"s}});
+    dm.createServiceManager<TestService, ITestService>(CppelixProperties{{"scope", "two"s}});
+    dm.createServiceManager<TrackerService, ITrackerService>();
     dm.start();
     auto end = std::chrono::system_clock::now();
     std::cout << fmt::format("Program ran for {:L} µs\n", std::chrono::duration_cast<std::chrono::microseconds>(end-start).count());

--- a/examples/yielding_timer_example/UsingTimerService.h
+++ b/examples/yielding_timer_example/UsingTimerService.h
@@ -15,11 +15,14 @@ struct IUsingTimerService : virtual public IService {
 
 class UsingTimerService final : public IUsingTimerService, public Service {
 public:
+    UsingTimerService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+        reg.registerDependency<ILogger>(this, true);
+    }
     ~UsingTimerService() final = default;
 
     bool start() final {
         LOG_INFO(_logger, "UsingTimerService started");
-        _timerManager = getManager()->createServiceManager<ITimer, Timer>();
+        _timerManager = getManager()->createServiceManager<Timer, ITimer>();
         _timerManager->setChronoInterval(std::chrono::milliseconds(500));
         _timerEventRegistration = getManager()->registerEventHandler<TimerEvent>(getServiceId(), this, _timerManager->getServiceId());
         _timerManager->startTimer();

--- a/examples/yielding_timer_example/main.cpp
+++ b/examples/yielding_timer_example/main.cpp
@@ -6,14 +6,12 @@
 
 #define FRAMEWORK_LOGGER_TYPE SpdlogFrameworkLogger
 #define LOGGER_TYPE SpdlogLogger
-#define LOGGER_SHARED_TYPE ,ISpdlogSharedService
 #else
 #include <optional_bundles/logging_bundle/CoutFrameworkLogger.h>
 #include <optional_bundles/logging_bundle/CoutLogger.h>
 
 #define FRAMEWORK_LOGGER_TYPE CoutFrameworkLogger
 #define LOGGER_TYPE CoutLogger
-#define LOGGER_SHARED_TYPE
 #endif
 #include <chrono>
 #include <iostream>
@@ -25,13 +23,13 @@ int main() {
 
     auto start = std::chrono::system_clock::now();
     DependencyManager dm{};
-    dm.createServiceManager<IFrameworkLogger, FRAMEWORK_LOGGER_TYPE>();
+    dm.createServiceManager<FRAMEWORK_LOGGER_TYPE, IFrameworkLogger>();
 #ifdef USE_SPDLOG
-    dm.createServiceManager<ISpdlogSharedService, SpdlogSharedService>();
+    dm.createServiceManager<SpdlogSharedService, ISpdlogSharedService>();
 #endif
-    dm.createServiceManager<ILoggerAdmin, LoggerAdmin<LOGGER_TYPE LOGGER_SHARED_TYPE>>(RequiredList<IFrameworkLogger>);
-    dm.createServiceManager<IUsingTimerService, UsingTimerService>(RequiredList<ILogger>, OptionalList<>);
-    dm.createServiceManager<IUsingTimerService, UsingTimerService>(RequiredList<ILogger>, OptionalList<>);
+    dm.createServiceManager<LoggerAdmin<LOGGER_TYPE>, ILoggerAdmin>();
+    dm.createServiceManager<UsingTimerService, IUsingTimerService>();
+    dm.createServiceManager<UsingTimerService, IUsingTimerService>();
     dm.start();
     auto end = std::chrono::system_clock::now();
     std::cout << fmt::format("Program ran for {:L} µs\n", std::chrono::duration_cast<std::chrono::microseconds>(end-start).count());

--- a/include/framework/Callback.h
+++ b/include/framework/Callback.h
@@ -1,19 +1,38 @@
 #pragma once
 
-struct CallbackKey {
-    uint64_t id;
-    uint64_t type;
+#include "Common.h"
 
-    bool operator==(const CallbackKey &other) const {
-        return id == other.id && type == other.type;
-    }
-};
+namespace Cppelix {
+    struct CallbackKey {
+        uint64_t id;
+        uint64_t type;
+
+        bool operator==(const CallbackKey &other) const {
+            return id == other.id && type == other.type;
+        }
+    };
+
+    struct InterfaceKey {
+        uint64_t typenameHash;
+        InterfaceVersion version;
+
+        bool operator==(const InterfaceKey &other) const {
+            return typenameHash == other.typenameHash && version == other.version;
+        }
+    };
+}
 
 namespace std {
     template <>
-    struct hash<CallbackKey> {
-        std::size_t operator()(const CallbackKey& k) const {
+    struct hash<Cppelix::CallbackKey> {
+        std::size_t operator()(const Cppelix::CallbackKey& k) const {
             return std::hash<uint64_t>()(k.id) ^ std::hash<uint64_t>()(k.type);
+        }
+    };
+    template <>
+    struct hash<Cppelix::InterfaceKey> {
+        std::size_t operator()(const Cppelix::InterfaceKey& k) const {
+            return std::hash<uint64_t>()(k.typenameHash) ^ std::hash<uint64_t>()(k.version.major) ^ std::hash<uint64_t>()(k.version.minor) ^ std::hash<uint64_t>()(k.version.patch);
         }
     };
 }

--- a/include/framework/Concepts.h
+++ b/include/framework/Concepts.h
@@ -5,6 +5,8 @@
 
 namespace Cppelix {
 
+    class DependencyRegister;
+
     template <class T, class U, class... Remainder>
     struct DerivedTrait : std::integral_constant<bool, DerivedTrait<T, Remainder...>::value && std::is_base_of_v<U, T>> {};
 
@@ -21,7 +23,12 @@ namespace Cppelix {
     concept Derived = std::is_base_of<U, T>::value;
 
     template <class T, class... U>
-    concept AllDerived = DerivedTrait<T, U...>::value;
+    concept ImplementsAll = DerivedTrait<T, U...>::value;
+
+    template <class ImplT>
+    concept RequestsDependencies = requires(ImplT impl, DependencyRegister &deps, CppelixProperties properties) {
+        { ImplT(deps, properties) };
+    };
 
     template <class ImplT, class Interface>
     concept ImplementsDependencyInjection = requires(ImplT impl, Interface *svc) {

--- a/include/framework/Events.h
+++ b/include/framework/Events.h
@@ -41,13 +41,13 @@ namespace Cppelix {
     };
 
     struct DependencyRequestEvent final : public Event {
-        explicit DependencyRequestEvent(uint64_t _id, uint64_t _originatingService, uint64_t _priority, std::shared_ptr<ILifecycleManager> _manager, Dependency _dependency, CppelixProperties const * _properties) noexcept :
+        explicit DependencyRequestEvent(uint64_t _id, uint64_t _originatingService, uint64_t _priority, std::shared_ptr<ILifecycleManager> _manager, Dependency _dependency, std::optional<CppelixProperties const *> _properties) noexcept :
                 Event(TYPE, NAME, _id, _originatingService, _priority), manager(std::move(_manager)), dependency(std::move(_dependency)), properties{_properties} {}
         ~DependencyRequestEvent() final = default;
 
         const std::shared_ptr<ILifecycleManager> manager;
         const Dependency dependency;
-        const CppelixProperties * properties;
+        const std::optional<CppelixProperties const *> properties;
         static constexpr uint64_t TYPE = typeNameHash<DependencyRequestEvent>();
         static constexpr std::string_view NAME= typeName<DependencyRequestEvent>();
     };

--- a/include/framework/Service.h
+++ b/include/framework/Service.h
@@ -33,6 +33,7 @@ namespace Cppelix {
     class Service : virtual public IService {
     public:
         Service() noexcept;
+        Service(CppelixProperties props) noexcept;
         ~Service() override;
 
         void injectDependencyManager(DependencyManager *mng) {
@@ -71,14 +72,17 @@ namespace Cppelix {
         sole::uuid _serviceGid;
         ServiceState _serviceState;
         static std::atomic<uint64_t> _serviceIdCounter;
-        DependencyManager *_manager;
+        DependencyManager *_manager{nullptr};
 
         friend class DependencyManager;
-        template<class ServiceType, typename... Dependencies>
+        template<class ServiceType>
         requires Derived<ServiceType, Service>
         friend class LifecycleManager;
         template<class ServiceType>
         requires Derived<ServiceType, Service>
-        friend class ServiceLifecycleManager;
+        friend class DependencyLifecycleManager;
+        template<class ServiceType>
+        requires Derived<ServiceType, Service>
+        friend class LifecycleManager;
     };
 }

--- a/include/optional_bundles/etcd_bundle/EtcdService.h
+++ b/include/optional_bundles/etcd_bundle/EtcdService.h
@@ -10,7 +10,7 @@ namespace Cppelix {
     public:
         static constexpr InterfaceVersion version = InterfaceVersion{1, 0, 0};
 
-        EtcdService() = default;
+        EtcdService(DependencyRegister &reg, CppelixProperties props);
         ~EtcdService() final = default;
 
         bool start() final;

--- a/include/optional_bundles/etcd_bundle/EtcdService.h
+++ b/include/optional_bundles/etcd_bundle/EtcdService.h
@@ -8,8 +8,6 @@
 namespace Cppelix {
     class EtcdService final : public IEtcdService, public Service {
     public:
-        static constexpr InterfaceVersion version = InterfaceVersion{1, 0, 0};
-
         EtcdService(DependencyRegister &reg, CppelixProperties props);
         ~EtcdService() final = default;
 

--- a/include/optional_bundles/logging_bundle/LoggerAdmin.h
+++ b/include/optional_bundles/logging_bundle/LoggerAdmin.h
@@ -39,8 +39,11 @@ namespace Cppelix {
         void handleDependencyRequest(ILogger *, DependencyRequestEvent const *const evt) {
             auto logger = _loggers.find(evt->originatingService);
 
-            auto requestedLevelIt = evt->properties->find("LogLevel");
-            auto requestedLevel = requestedLevelIt != end(*evt->properties) ? std::any_cast<LogLevel>(requestedLevelIt->second) : LogLevel::INFO;
+            auto requestedLevel = LogLevel::INFO;
+            if(evt->properties.has_value()) {
+                auto requestedLevelIt = evt->properties.value()->find("LogLevel");
+                requestedLevel = requestedLevelIt != end(*evt->properties.value()) ? std::any_cast<LogLevel>(requestedLevelIt->second) : LogLevel::INFO;
+            }
             if (logger == end(_loggers)) {
                 LOG_TRACE(_logger, "creating logger for svcid {}", evt->originatingService);
                     _loggers.emplace(evt->originatingService, getManager()->template createServiceManager<LogT, ILogger>(

--- a/include/optional_bundles/logging_bundle/SpdlogLogger.h
+++ b/include/optional_bundles/logging_bundle/SpdlogLogger.h
@@ -15,6 +15,8 @@ namespace spdlog {
 namespace Cppelix {
     class SpdlogLogger final : public ILogger, public Service {
     public:
+        SpdlogLogger(DependencyRegister &reg, CppelixProperties props);
+
         bool start() final;
         bool stop() final;
 

--- a/include/optional_bundles/metrics_bundle/EventStatisticsService.h
+++ b/include/optional_bundles/metrics_bundle/EventStatisticsService.h
@@ -38,7 +38,7 @@ namespace Cppelix {
 
     class EventStatisticsService final : public IEventStatisticsService, public Service {
     public:
-        EventStatisticsService() = default;
+        EventStatisticsService(DependencyRegister &reg, CppelixProperties props);
         ~EventStatisticsService() final = default;
 
         void addDependencyInstance(ILogger *logger);

--- a/include/optional_bundles/network_bundle/ClientAdmin.h
+++ b/include/optional_bundles/network_bundle/ClientAdmin.h
@@ -40,7 +40,7 @@ namespace Cppelix {
             newProps.emplace("Filter", Filter{ServiceIdFilterEntry{evt->originatingService}});
 
             if(!_connections.contains(evt->originatingService)) {
-                _connections.emplace(evt->originatingService, getManager()->template createServiceManager<IConnectionService, NetworkType>(RequiredList<ILogger>, OptionalList<>, newProps));
+                _connections.emplace(evt->originatingService, getManager()->template createServiceManager<NetworkType, IConnectionService>(newProps));
             }
         }
 

--- a/include/optional_bundles/network_bundle/ClientAdmin.h
+++ b/include/optional_bundles/network_bundle/ClientAdmin.h
@@ -9,8 +9,6 @@ namespace Cppelix {
     template <typename NetworkType>
     class ClientAdmin final : public IClientAdmin, public Service {
     public:
-        static constexpr InterfaceVersion version = InterfaceVersion{1, 0, 0};
-
         ClientAdmin() = default;
         ~ClientAdmin() override = default;
 
@@ -28,15 +26,19 @@ namespace Cppelix {
         }
 
         void handleDependencyRequest(IConnectionService*, DependencyRequestEvent const * const evt) {
-            if(!evt->properties->contains("Address")) {
+            if(!evt->properties.has_value()) {
+                throw std::runtime_error("Missing properties");
+            }
+
+            if(!evt->properties.value()->contains("Address")) {
                 throw std::runtime_error("Missing address");
             }
 
-            if(!evt->properties->contains("Port")) {
+            if(!evt->properties.value()->contains("Port")) {
                 throw std::runtime_error("Missing port");
             }
 
-            auto newProps = *evt->properties;
+            auto newProps = *evt->properties.value();
             newProps.emplace("Filter", Filter{ServiceIdFilterEntry{evt->originatingService}});
 
             if(!_connections.contains(evt->originatingService)) {

--- a/include/optional_bundles/network_bundle/tcp/TcpConnectionService.h
+++ b/include/optional_bundles/network_bundle/tcp/TcpConnectionService.h
@@ -7,8 +7,6 @@
 namespace Cppelix {
     class TcpConnectionService final : public IConnectionService, public Service {
     public:
-        static constexpr InterfaceVersion version = InterfaceVersion{1, 0, 0};
-
         TcpConnectionService(DependencyRegister &reg, CppelixProperties props);
         ~TcpConnectionService() final = default;
 

--- a/include/optional_bundles/network_bundle/tcp/TcpConnectionService.h
+++ b/include/optional_bundles/network_bundle/tcp/TcpConnectionService.h
@@ -9,7 +9,7 @@ namespace Cppelix {
     public:
         static constexpr InterfaceVersion version = InterfaceVersion{1, 0, 0};
 
-        TcpConnectionService();
+        TcpConnectionService(DependencyRegister &reg, CppelixProperties props);
         ~TcpConnectionService() final = default;
 
         bool start() final;

--- a/include/optional_bundles/network_bundle/tcp/TcpHostService.h
+++ b/include/optional_bundles/network_bundle/tcp/TcpHostService.h
@@ -10,7 +10,7 @@ namespace Cppelix {
     public:
         static constexpr InterfaceVersion version = InterfaceVersion{1, 0, 0};
 
-        TcpHostService();
+        TcpHostService(DependencyRegister &reg, CppelixProperties props);
         ~TcpHostService() final = default;
 
         bool start() final;

--- a/include/optional_bundles/network_bundle/tcp/TcpHostService.h
+++ b/include/optional_bundles/network_bundle/tcp/TcpHostService.h
@@ -8,8 +8,6 @@
 namespace Cppelix {
     class TcpHostService final : public IHostService, public Service {
     public:
-        static constexpr InterfaceVersion version = InterfaceVersion{1, 0, 0};
-
         TcpHostService(DependencyRegister &reg, CppelixProperties props);
         ~TcpHostService() final = default;
 

--- a/include/optional_bundles/serialization_bundle/SerializationAdmin.h
+++ b/include/optional_bundles/serialization_bundle/SerializationAdmin.h
@@ -9,7 +9,7 @@ namespace Cppelix {
 
     class SerializationAdmin final : public ISerializationAdmin, public Service {
     public:
-        SerializationAdmin() = default;
+        SerializationAdmin(DependencyRegister &reg, CppelixProperties props);
         ~SerializationAdmin() final = default;
 
         std::vector<uint8_t> serialize(const uint64_t type, const void* obj) final;

--- a/src/framework/Service.cpp
+++ b/src/framework/Service.cpp
@@ -6,6 +6,10 @@ Cppelix::Service::Service() noexcept : IService(), _serviceId(_serviceIdCounter.
 
 }
 
+Cppelix::Service::Service(Cppelix::CppelixProperties props) noexcept : IService(), _properties(std::move(props)), _serviceId(_serviceIdCounter.fetch_add(1, std::memory_order_acq_rel)), _serviceGid(sole::uuid4()), _serviceState(ServiceState::INSTALLED) {
+
+}
+
 Cppelix::Service::~Service() {
     _serviceId = 0;
     _serviceGid.ab = 0;

--- a/src/optional_bundles/etcd_bundle/EtcdService.cpp
+++ b/src/optional_bundles/etcd_bundle/EtcdService.cpp
@@ -5,6 +5,11 @@
 #include <optional_bundles/etcd_bundle/auth.pb.h>
 #include <grpc++/grpc++.h>
 
+
+Cppelix::EtcdService::EtcdService(Cppelix::DependencyRegister &reg, Cppelix::CppelixProperties props) : Service(std::move(props)) {
+    reg.registerDependency<ILogger>(this, true);
+}
+
 bool Cppelix::EtcdService::start() {
     auto addressProp = getProperties()->find("EtcdAddress");
     if(addressProp == end(*getProperties())) {

--- a/src/optional_bundles/logging_bundle/SpdlogLogger.cpp
+++ b/src/optional_bundles/logging_bundle/SpdlogLogger.cpp
@@ -4,6 +4,11 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include "optional_bundles/logging_bundle/SpdlogLogger.h"
+#include <framework/DependencyManager.h>
+
+Cppelix::SpdlogLogger::SpdlogLogger(Cppelix::DependencyRegister &reg, Cppelix::CppelixProperties props) : Service(std::move(props)) {
+    reg.registerDependency<ISpdlogSharedService>(this, true);
+}
 
 void Cppelix::SpdlogLogger::trace(const char *filename_in, int line_in, const char *funcname_in,
                                            std::string_view format_str, fmt::format_args args) {

--- a/src/optional_bundles/metrics_bundle/EventStatisticsService.cpp
+++ b/src/optional_bundles/metrics_bundle/EventStatisticsService.cpp
@@ -1,5 +1,9 @@
 #include <optional_bundles/metrics_bundle/EventStatisticsService.h>
 
+Cppelix::EventStatisticsService::EventStatisticsService(Cppelix::DependencyRegister &reg, Cppelix::CppelixProperties props) : Service(std::move(props)) {
+    reg.registerDependency<ILogger>(this, true);
+}
+
 bool Cppelix::EventStatisticsService::start() {
     if(getProperties()->contains("ShowStatisticsOnStop")) {
         _showStatisticsOnStop = std::any_cast<bool>(getProperties()->operator[]("ShowStatisticsOnStop"));
@@ -11,7 +15,7 @@ bool Cppelix::EventStatisticsService::start() {
         _averagingIntervalMs = 5000;
     }
 
-    auto _timerManager = getManager()->createServiceManager<ITimer, Timer>();
+    auto _timerManager = getManager()->createServiceManager<Timer, ITimer>();
     _timerManager->setChronoInterval(std::chrono::milliseconds(_averagingIntervalMs));
     _timerEventRegistration = getManager()->registerEventHandler<TimerEvent>(getServiceId(), this, _timerManager->getServiceId());
     _timerManager->startTimer();

--- a/src/optional_bundles/network_bundle/tcp/TcpConnectionService.cpp
+++ b/src/optional_bundles/network_bundle/tcp/TcpConnectionService.cpp
@@ -6,8 +6,8 @@
 #include <netinet/tcp.h>
 #include <unistd.h>
 
-Cppelix::TcpConnectionService::TcpConnectionService() : _socket(-1), _attempts(), _priority(INTERNAL_EVENT_PRIORITY),  _quit(), _listenThread() {
-
+Cppelix::TcpConnectionService::TcpConnectionService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)), _socket(-1), _attempts(), _priority(INTERNAL_EVENT_PRIORITY),  _quit(), _listenThread() {
+    reg.registerDependency<ILogger>(this, true);
 }
 
 bool Cppelix::TcpConnectionService::start() {

--- a/src/optional_bundles/network_bundle/tcp/TcpHostService.cpp
+++ b/src/optional_bundles/network_bundle/tcp/TcpHostService.cpp
@@ -8,8 +8,8 @@
 #include <unistd.h>
 #include <netdb.h>
 
-Cppelix::TcpHostService::TcpHostService() : _socket(-1), _bindFd(), _priority(INTERNAL_EVENT_PRIORITY), _quit(), _listenThread() {
-
+Cppelix::TcpHostService::TcpHostService(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)), _socket(-1), _bindFd(), _priority(INTERNAL_EVENT_PRIORITY), _quit(), _listenThread() {
+    reg.registerDependency<ILogger>(this, true);
 }
 
 bool Cppelix::TcpHostService::start() {
@@ -87,8 +87,7 @@ bool Cppelix::TcpHostService::start() {
             auto ip = ::inet_ntoa(client_addr.sin_addr);
             LOG_TRACE(_logger, "new connection from {}:{}", ip, ::ntohs(client_addr.sin_port));
 
-            auto connection = getManager()->template createServiceManager<IConnectionService, TcpConnectionService>(RequiredList<ILogger>, OptionalList<>,
-                    CppelixProperties{{"Priority", _priority.load(std::memory_order_acquire)}, {"Socket", newConnection}});
+            auto connection = getManager()->template createServiceManager<TcpConnectionService, IConnectionService>(CppelixProperties{{"Priority", _priority.load(std::memory_order_acquire)}, {"Socket", newConnection}});
 
             _connections.emplace_back(connection);
         }

--- a/src/optional_bundles/serialization_bundle/SerializationAdmin.cpp
+++ b/src/optional_bundles/serialization_bundle/SerializationAdmin.cpp
@@ -1,6 +1,10 @@
 #include <optional_bundles/serialization_bundle/SerializationAdmin.h>
 #include <framework/DependencyManager.h>
 
+Cppelix::SerializationAdmin::SerializationAdmin(DependencyRegister &reg, CppelixProperties props) : Service(std::move(props)) {
+    reg.registerDependency<ILogger>(this, true);
+}
+
 std::vector<uint8_t> Cppelix::SerializationAdmin::serialize(const uint64_t type, const void* obj) {
     auto serializer = _serializers.find(type);
     if(serializer == end(_serializers)) {


### PR DESCRIPTION
WIP

@Troepje Does this look like an improvement? Performance wise, it's more or less the same as the previous situation. Memory-wise, there's some extra memory usage because of duplicated dependency tracking.